### PR TITLE
Gentype support

### DIFF
--- a/src/bsconfig.rs
+++ b/src/bsconfig.rs
@@ -351,7 +351,7 @@ impl Config {
             },
             Ok(false) => vec![],
             Err(_) => {
-                eprintln!("Could not parse version: {}", version);
+                eprintln!("Could not establish Rescript Version number for uncurried mode. Defaulting to Rescript < 11, disabling uncurried mode. Please specify an exact version if you need > 11 and default uncurried mode. Version: {}", version);
                 vec![]
             }
         }

--- a/src/bsconfig.rs
+++ b/src/bsconfig.rs
@@ -245,7 +245,17 @@ pub fn read(path: String) -> Config {
 }
 
 fn check_if_rescript11_or_higher(version: &str) -> bool {
-    version.split('.').next().unwrap().parse::<usize>().unwrap() >= 11
+    // Non stable rescript versions might contain non-numeric characters
+    let filter_non_number_chars = |s: &str| s.chars().filter(|c| c.is_numeric()).collect::<String>();
+
+    version
+        .split('.')
+        .next()
+        .map(filter_non_number_chars)
+        .unwrap()
+        .parse::<usize>()
+        .unwrap()
+        >= 11
 }
 
 fn namespace_from_package_name(package_name: &str) -> String {

--- a/src/bsconfig.rs
+++ b/src/bsconfig.rs
@@ -133,9 +133,8 @@ pub struct JsxSpecs {
     pub v3_dependencies: Option<Vec<String>>,
 }
 
-/// Empty struct - the gentype config is loaded by bsc
-#[derive(Deserialize, Debug, Clone)]
-pub struct GenTypeConfig {}
+/// We do not care about the internal structure because the gentype config is loaded by bsc.
+pub type GenTypeConfig = serde_json::Value;
 
 /// # bsconfig.json representation
 /// This is tricky, there is a lot of ambiguity. This is probably incomplete.

--- a/src/bsconfig.rs
+++ b/src/bsconfig.rs
@@ -244,17 +244,11 @@ pub fn read(path: String) -> Config {
 }
 
 fn check_if_rescript11_or_higher(version: &str) -> bool {
-    // Non stable rescript versions might contain non-numeric characters
-    let filter_non_number_chars = |s: &str| s.chars().filter(|c| c.is_numeric()).collect::<String>();
-
-    version
-        .split('.')
-        .next()
-        .map(filter_non_number_chars)
-        .unwrap()
-        .parse::<usize>()
-        .unwrap()
-        >= 11
+    if let Some(major) = version.split('.').next().and_then(|s| s.parse::<usize>().ok()) {
+        major >= 11
+    } else {
+        false
+    }
 }
 
 fn namespace_from_package_name(package_name: &str) -> String {
@@ -432,5 +426,24 @@ mod tests {
         let config = serde_json::from_str::<Config>(json).unwrap();
         assert_eq!(config.gentype_config.is_some(), true);
         assert_eq!(config.get_gentype_arg(), vec!["-bs-gentype".to_string()]);
+    }
+
+    #[test]
+    fn test_check_if_rescript11_or_higher() {
+        assert_eq!(check_if_rescript11_or_higher("11.0.0"), true);
+        assert_eq!(check_if_rescript11_or_higher("11.0.1"), true);
+        assert_eq!(check_if_rescript11_or_higher("11.1.0"), true);
+
+        assert_eq!(check_if_rescript11_or_higher("12.0.0"), true);
+
+        assert_eq!(check_if_rescript11_or_higher("10.0.0"), false);
+        assert_eq!(check_if_rescript11_or_higher("9.0.0"), false);
+    }
+
+    #[test]
+    fn test_check_if_rescript11_or_higher_misc() {
+        assert_eq!(check_if_rescript11_or_higher("11"), true);
+        assert_eq!(check_if_rescript11_or_higher("*"), false);
+        assert_eq!(check_if_rescript11_or_higher("12.0.0-alpha.4"), true);
     }
 }

--- a/src/build/compile.rs
+++ b/src/build/compile.rs
@@ -434,6 +434,7 @@ pub fn compiler_args(
     let jsx_module_args = root_config.get_jsx_module_args();
     let jsx_mode_args = root_config.get_jsx_mode_args();
     let uncurried_args = root_config.get_uncurried_args(version);
+    let gentype_arg = root_config.get_gentype_arg();
 
     let warning_args: Vec<String> = match config.warnings.to_owned() {
         None => vec![],
@@ -494,6 +495,7 @@ pub fn compiler_args(
         read_cmi_args,
         vec!["-I".to_string(), ".".to_string()],
         deps.concat(),
+        gentype_arg,
         jsx_args,
         jsx_module_args,
         jsx_mode_args,

--- a/src/build/packages.rs
+++ b/src/build/packages.rs
@@ -864,6 +864,7 @@ mod test {
                 namespace: None,
                 jsx: None,
                 uncurried: None,
+                gentype_config: None,
                 namespace_entry: None,
                 allowed_dependents,
             },


### PR DESCRIPTION
This PR adds support for gentype to rewatch.
With the upcoming v11 compiler version it will then generate the appropriate `.tsx` files.

Fixes #102