### PR TITLE
build binaries for Linux ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
         shell: bash
         run: |
           rustup target add x86_64-unknown-linux-musl \
+            aarch64-unknown-linux-musl \
             aarch64-apple-darwin \
             x86_64-apple-darwin \
             x86_64-pc-windows-gnu
@@ -46,11 +47,14 @@ jobs:
         run: cargo zigbuild --target universal2-apple-darwin --release
       - name: Linux - build x86_64 musl
         run: cargo zigbuild --target x86_64-unknown-linux-musl --release
+      - name: Linux - build aarch64 musl
+        run: cargo zigbuild --target aarch64-unknown-linux-musl --release
       - name: Windows - build x86_64 musl
         run: cargo zigbuild --target x86_64-pc-windows-gnu --release
       - name: Move / Rename Artifacts
         run: |
           mv target/x86_64-unknown-linux-musl/release/rewatch ./rewatch-linux
+          mv target/aarch64-unknown-linux-musl/release/rewatch ./rewatch-linux-arm64
           mv target/universal2-apple-darwin/release/rewatch ./rewatch-macos
           mv target/x86_64-pc-windows-gnu/release/rewatch.exe ./rewatch-windows.exe
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "/rewatch",
     "/rewatch.cmd",
     "/rewatch-linux",
+    "/rewatch-linux-arm64",
     "/rewatch-macos",
     "/rewatch-windows.exe"
   ]

--- a/postinstall.js
+++ b/postinstall.js
@@ -35,7 +35,11 @@ const installWindowsBinary = () => {
 
 switch (process.platform) {
   case "linux":
-    installMacLinuxBinary("rewatch-linux");
+    if (process.arch === "arm64") {
+      installMacLinuxBinary("rewatch-linux-arm64");
+    } else {
+      installMacLinuxBinary("rewatch-linux");
+    }
     break;
   case "darwin":
     installMacLinuxBinary("rewatch-macos");

--- a/rewatch
+++ b/rewatch
@@ -8,7 +8,12 @@ if [ "$(uname)" = "Darwin" ]; then
     $DIR/rewatch-macos.exe $@
 elif [ "$(expr substr $(uname -s) 1 5)" = "Linux" ]; then
     # Run the Linux Version
-    $DIR/rewatch-linux.exe $@
+    elif [ "$(expr substr $(uname -m) 1 7)" = "aarch64" ]; then
+        # Run the Linux ARM64 Version
+        $DIR/rewatch-linux-arm64.exe $@
+    else 
+        $DIR/rewatch-linux.exe $@
+    fi
 else
     echo "No release available for '$(uname)'"
     exit 1

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -140,6 +140,7 @@ pub fn get_bsc(root_path: &str, workspace_root: Option<String>) -> String {
     let subfolder = match (std::env::consts::OS, std::env::consts::ARCH) {
         ("macos", "aarch64") => "darwinarm64",
         ("macos", _) => "darwin",
+        ("linux", "aarch64") => "linuxarm64",
         ("linux", _) => "linux",
         ("windows", _) => "win32",
         _ => panic!("Unsupported architecture"),


### PR DESCRIPTION
Today rescript ships bsb for ARM64 but not rewatch, so this PR allows rewatch to support the same targets.